### PR TITLE
July 2020 - QM 20.07.0 (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## Quantum Mobile v20.07.0
+
+### Improvements
+
+- Re-added BigDFT
+
+### Software updates
+
+- Yambo 4.5.2
+- Siesta 4.1-rc2
+- aiida-bigdft 0.2.1a2
+- aiida-quantumespresso 3.1.0
+
+### Software summary
+
+- OS: Ubuntu 18.04.4 LTS, Linux 4.15.0-112, VirtualBox 6.1.12
+- tools: atomistic (xcrysden, jmol, cif2cell, ase, pymatgen, seekpath, spglib), visualization (grace, gnuplot, matplotlib, bokeh, jupyter), simulation environment (slurm, OpenMPI, FFT/BLAS/LAPACK, gcc, gfortran, singularity)
+- aiida-core                      1.3.0
+  - aiida-bands-inspect             0.4.0
+  - aiida-bigdft                    0.2.1a2
+  - aiida-codtools                  2.1.0
+  - aiida-cp2k                      1.1.0
+  - aiida-ddec                      1.0.0a1
+  - aiida-diff                      1.2.0
+  - aiida-fleur                     1.1.0
+  - aiida-lsmo                      1.0.0b2
+  - aiida-optimize                  0.3.1
+  - aiida-qeq                       1.0.0a1
+  - aiida-quantumespresso           3.1.0
+  - aiida-raspa                     1.1.1
+  - aiida-siesta                    1.0.1
+  - aiida-tbmodels                  0.4.0rc1
+  - aiida-tools                     0.3.3
+  - aiida-vasp                      0.2.4
+  - aiida-wannier90                 2.0.1
+  - aiida-wannier90-workflows       1.0.1
+  - aiida-yambo                     1.1.1
+  - aiida-zeopp                     1.1.1
+- aiidalab                        20.7.0b2
+  - aiidalab-widgets-base           1.0.0b7
+- simulation codes:
+  - Quantum Espresso 6.5
+  - Yambo     4.5.2
+  - fleur     0.30 MaX4
+  - siesta    v4.1-rc2
+  - cp2k      7.1
+  - Wannier90 3.1.0
+  - BigDFT 1.9.0
+- pseudopotentials
+  - SSSP (PBE) efficiency v1.1
+  - SSSP (PBE) precision v1.1
+  - SG15 ONCV v1.1
+
+### Build process
+
+- ansible 2.9.9
+- Vagrant v2.2.9
+  - vbguest v0.24.0
+  - bento/ubuntu-18.04 v202007.17.0
+- Virtualbox v6.1.12
+
+
 ## Quantum Mobile v20.06.1a1
 
 ### Improvements
@@ -55,6 +117,7 @@
 
 BigDFT is not installed, since a fix is outstanding for <https://github.com/marvel-nccr/ansible-role-bigdft/issues/8>.
 
+
 ## Quantum Mobile v20.03.0
 
 ### Improvements
@@ -82,6 +145,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
   - aiidalab v20.2.0b2
   - aiida-wannier90 v2.0.0
 
+
 ## Quantum Mobile v19.12.0
 
 ### Improvements
@@ -101,6 +165,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 - QE 6.5 with EPW and Wannier90
 - fleur 0.30 MaxR4
 
+
 ## Quantum Mobile v19.09.0
 
 ### Improvements
@@ -112,6 +177,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 - aiida-core v1.0.0b6
   - aiida-quantumespresso v3.0.0a4
 - aiidalab v19.08.0a1
+
 
 ## Quantum Mobile v19.07.0
 
@@ -130,6 +196,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
   - vbguest v0.19.0
   - bento/ubuntu-18.04 v201906.18.0
 - Virtualbox v6.0.10
+
 
 ## Quantum Mobile v19.03.0
 
@@ -176,6 +243,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 - Roles are installed via ansible-galaxy
 - Continuous integration tests for individual roles 
 
+
 ## Quantum Mobile v18.04.0
 
 ### Software updates
@@ -203,6 +271,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
   `ansible-playbook playbook.yml -i inventory_file`
 - Adjustments for ansible 2.5
 
+
 ## Quantum Mobile v18.03.0
 
 ### Improvements
@@ -213,12 +282,14 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 
 - VM image built using Virtualbox 5.2.8
 
+
 ## Quantum Mobile v18.02.2
 
 ### Software updates
 
 - aiida-core v0.11.0
 - aiida-siesta v0.11.5
+
 
 ## Quantum Mobile v18.02.0
 
@@ -238,6 +309,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 
 - VM image built using Virtualbox 5.2.6 + Guest Additions 5.2.7
 
+
 ## Quantum Mobile v17.12.0
 
 ### Improvements
@@ -256,6 +328,7 @@ BigDFT is not installed, since a fix is outstanding for <https://github.com/marv
 
 - VM image built using Virtualbox 5.2.4
 - Size of VM image and virtual disk added to install instructions
+
 
 ## Quantum Mobile v17.11.0
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,8 +11,8 @@ Get Quantum Mobile running on your computer in three simple steps:
  3. Import virtual machine image into Virtualbox (${vm_vdisk_size})
     File => Import Appliance
 
-Login credentials: username: `${vm_user}`, password: `${vm_password}`.  
-The default configuration of `${vm_cpus}` cores and `${vm_memory}` MB RAM can be adjusted in the VM settings.
+Login credentials: username: `${vm_user}`, password: `${vm_password}`.
+The default configuration of ${vm_cpus} cores and ${vm_memory} MB RAM can be adjusted in the VM settings.
 
 
 ## Contact

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,8 @@ Vagrant.configure(2) do |config|
   #config.vm.box_version = "201910.21.0"
   #config.vm.box = "ubuntu/xenial64"
   config.vm.boot_timeout = 120
+  # The machine takes a long time to shut down
+  config.vm.graceful_halt_timeout = 360
 
   ## In case you need to specify explicitly SSH credentials...
   #config.ssh.username = "ubuntu"
@@ -73,7 +75,7 @@ Vagrant.configure(2) do |config|
   # provisioner: set up VM via ansible. To (re-)run this step:
   #   vagrant provision --provision-with ansible
   config.vm.provision "ansible" do |ansible|
-    ansible.verbose = "v"
+    ansible.verbose = "vv"
     ansible.playbook = "playbook.yml"
     ansible.extra_vars = {
        ansible_python_interpreter: "/usr/bin/python3",

--- a/create_image.sh
+++ b/create_image.sh
@@ -37,15 +37,20 @@ echo "### Find image in $fname"
 
 echo "### Computing size of vm image and vm disk"
 vm_image_size=`du -sh $fname  | awk '{print $1}'`
-vm_image_md5=`md5sum $fname  | awk '{print $4}'`
 vdisk_path_grep=`vboxmanage showvminfo --machinereadable "$vm_id" | grep vmdk `
 [[ $vdisk_path_grep =~ ^.*=\"(.*)\"$ ]]
 vdisk_path=${BASH_REMATCH[1]}
 vm_vdisk_size=`du -sh "$vdisk_path" | awk '{print $1}' `
 echo "### vdisk size: $vm_vdisk_size"
 echo "### image size: $vm_image_size"
+if vm_image_md5=$(md5 $fname 2>/dev/null); then  # MacOS
+    vm_image_md5=$(echo $vm_image_md5 | awk '{print $4}')
+elif vm_image_md5=$(md5sum $fname 2>/dev/null); then  # Linux
+    vm_image_md5=$(echo $vm_image_md5 | awk '{print $1}')
+fi
+echo "### image md5: $vm_image_md5"
 
-export fname vm_version vm_user vm_password 
+export fname vm_version vm_user vm_password vm_cpus vm_memory
 export vm_image_size vm_image_md5 vm_vdisk_size
 envsubst < INSTALL.md > INSTALL_${vm_version}.txt
 echo "### Instructions in INSTALL_${vm_version}${rc}.txt"

--- a/globalconfig.yml
+++ b/globalconfig.yml
@@ -1,7 +1,7 @@
 ---
 # Caution: This file is read by vagrant, ansible and bash
 vm_name: "Quantum Mobile"
-vm_version: "20.06.1"
+vm_version: "20.07.0"
 vm_description: "A Virtual Machine for Computational Materials Science"
 vm_url: "https://github.com/marvel-nccr/marvel-virtualmachine"
 vm_author: "MARVEL NCCR and MaX CoE"

--- a/playbook.yml
+++ b/playbook.yml
@@ -95,8 +95,8 @@
     - role: marvel-nccr.wannier_tools
       tags: wannier_tools
     # this can be added back when ansible-role-bigdft/issues/8 is fixed
-    #- role: marvel-nccr.bigdft
-    #  tags: bigdft
+    - role: marvel-nccr.bigdft
+      tags: bigdft
     - role: marvel-nccr.aiidalab
       become: true
       become_user: "{{ vm_user }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -12,7 +12,7 @@
 - src: marvel-nccr.ubuntu_desktop
   version: v1.0.4
 - src: marvel-nccr.quantum_mobile_customizations
-  version: v1.0.6
+  version: v1.0.7
 - src: marvel-nccr.editors
   version: v1.0.2
 - src: marvel-nccr.slurm
@@ -20,20 +20,20 @@
 - src: marvel-nccr.quantum_espresso
   version: v1.1.4
 - src: marvel-nccr.yambo
-  version: v1.1.0
+  version: v1.1.1
 - src: marvel-nccr.fleur
   version: v1.0.2
 - src: marvel-nccr.siesta
-  version: v1.0.4
+  version: v1.0.5
 - src: marvel-nccr.cp2k
   version: v1.1.1
 - src: marvel-nccr.bigdft
-  version: v1.3.0
+  version: v1.3.1
 - src: marvel-nccr.wannier90
   version: v1.1.2
 - src: marvel-nccr.wannier_tools
   version: v1.0.0
 - src: marvel-nccr.aiida
-  version: v2.3.2
+  version: v2.4.0
 - src: marvel-nccr.aiidalab
   version: v1.2.2


### PR DESCRIPTION
- Fix md5 computation;
- fix printing vm_cpus and vm_memory in INSTALL_*.md;
- codes:
  - Yambo 4.5.2
  - Siesta 4.1-rc2
  - re-add BigDFT 1.9.0
- aiida plugins:
  - aiida-bigdft 0.2.1a2
  - aiida-quantumespresso 3.1.0
- bump version to 20.07.0