### PR TITLE
Update launch.md

### DIFF
--- a/docs/users/launch.md
+++ b/docs/users/launch.md
@@ -14,7 +14,7 @@ The Docker images can be found on [DockerHub](https://hub.docker.com/r/marvelncc
 The easiest way to spawn a working container is to create a `docker-compose.yml`, and launch it with `docker-compose up -d`.
 
 ```yaml
-version: '3'
+version: '3.4'
 
 services:
   quantum-mobile:


### PR DESCRIPTION
Update docker-compose file version to '3.4'. The `start_period` 
property may otherwise not be supported.

That's the version I needed to specify to be able to successfully launch this on Ubuntu 18.04 with `Docker version 20.10.3, build 48d30b5` and `docker-compose version 1.17.1, build unknown`. 

This appears to be related to https://github.com/docker/compose/issues/5177.