### PR TITLE
Set the correct `mpirun_command` for the `marvel.aiida` role

### DIFF
--- a/inventory.yml
+++ b/inventory.yml
@@ -34,6 +34,7 @@ all:
     vm_headless: false
     vm_browser: chromium-browser  # 'chromium-browser' or 'firefox'
     vm_scheduler: slurm  # 'slurm' or 'direct'
+    vm_mpirun_command: "srun -n {tot_num_mpiprocs}"  # Should be set if `slurm` is set for `vm_scheduler`
 
     # Python virtual environments base location
     aiida_venv_base: "${HOME}/.virtualenvs"

--- a/playbook-build-qe.yml
+++ b/playbook-build-qe.yml
@@ -99,6 +99,7 @@
       aiida_data_folder: "{{ vm_data_folder }}/aiida"
       aiida_computer_cpus: "{{ vm_cpus }}"
       aiida_computer_scheduler: "{{ vm_scheduler }}"
+      aiida_computer_mpirun_command: "{{ vm_mpirun_command }}"
       aiida_examples_folder: "{{ vm_examples_folder }}"
       aiida_venv: "{{ aiida_venv_base }}/aiida"
       aiida_jupyter_venv: "{{ aiida_venv_base }}/jupyter"

--- a/playbook-build.yml
+++ b/playbook-build.yml
@@ -151,6 +151,7 @@
       aiida_data_folder: "{{ vm_data_folder }}/aiida"
       aiida_computer_cpus: "{{ vm_cpus }}"
       aiida_computer_scheduler: "{{ vm_scheduler }}"
+      aiida_computer_mpirun_command: "{{ vm_mpirun_command }}"
       aiida_examples_folder: "{{ vm_examples_folder }}"
       aiida_venv: "{{ aiida_venv_base }}/aiida"
       aiida_jupyter_venv: "{{ aiida_venv_base }}/jupyter"


### PR DESCRIPTION
Fixes #177 

The role is configured to setup the localhost using the SLURM scheduler
in which case the `mpirun_command` should be set to `srun`.

Note this is blocked by an update of the `marvel.aiida` ansible role: https://github.com/marvel-nccr/ansible-role-aiida/pull/69